### PR TITLE
Add `-o`, `--output` flag to golangci-custom

### DIFF
--- a/pkg/commands/custom.go
+++ b/pkg/commands/custom.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/golangci/golangci-lint/pkg/commands/internal"
@@ -12,6 +14,10 @@ import (
 )
 
 const envKeepTempFiles = "CUSTOM_GCL_KEEP_TEMP_FILES"
+
+var (
+	outputArgument = ""
+)
 
 type customCommand struct {
 	cmd *cobra.Command
@@ -33,6 +39,8 @@ func newCustomCommand(logger logutils.Log) *customCommand {
 		SilenceUsage: true,
 	}
 
+	customCmd.Flags().StringVarP(&outputArgument, "output", "o", "", color.GreenString("Path to output file"))
+
 	c.cmd = customCmd
 
 	return c
@@ -42,6 +50,12 @@ func (c *customCommand) preRunE(_ *cobra.Command, _ []string) error {
 	cfg, err := internal.LoadConfiguration()
 	if err != nil {
 		return err
+	}
+
+	if outputArgument != "" {
+		directory, name := path.Split(outputArgument)
+		cfg.Destination = directory
+		cfg.Name = name
 	}
 
 	err = cfg.Validate()


### PR DESCRIPTION
> [!NOTE]
> `golangci-lint` maintainer [refuses to consider this change](https://github.com/golangci/golangci-lint/issues/5369#issuecomment-2629898971).

Confirmed the help output is as expected:

```
Build a version of golangci-lint with custom linters

Usage:
  golangci-lint custom [flags]

Flags:
  -o, --output string   Path to output file

Global Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -h, --help           Help for a command
  -v, --verbose        Verbose output
```

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->
